### PR TITLE
Update probe_modules.c

### DIFF
--- a/probe_modules.c
+++ b/probe_modules.c
@@ -74,7 +74,7 @@ void fs_add_ip_fields(fieldset_t *fs, struct ip *ip)
 
 #define TIMESTR_LEN 55
 
-void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown)
+void fs_add_system_fields(fieldset_t *fs, int is_repeat, int in_cooldown, const struct timespec ts)
 {
         fs_add_bool(fs, "repeat", is_repeat);
         fs_add_bool(fs, "cooldown", in_cooldown);


### PR DESCRIPTION
Looks like there might be a regression from a fix introduced for issue #3  , when I re-add ", const struct timespec ts)" to line 77, the cmake builds correctly. Without, it throws the same error mentioned in the initial issue publication.